### PR TITLE
fix: preserve manifest.initial.animation across parse/serialize roundtrip

### DIFF
--- a/.changeset/mighty-moments-stare.md
+++ b/.changeset/mighty-moments-stare.md
@@ -1,0 +1,5 @@
+---
+'@dotlottie/dotlottie-js': patch
+---
+
+Preserve `manifest.initial.animation` across v2 parse/serialize roundtrips and v1→v2 migration

--- a/packages/dotlottie-js/src/v2/__tests__/browser/dotlottie.spec.ts
+++ b/packages/dotlottie-js/src/v2/__tests__/browser/dotlottie.spec.ts
@@ -605,6 +605,52 @@ describe('fromArrayBuffer', () => {
   });
 });
 
+describe('manifest.initial roundtrip', () => {
+  test('preserves manifest.initial.animation when the initial animation is not at index 0', async () => {
+    const source = new DotLottie()
+      .addAnimation({
+        id: 'first',
+        data: structuredClone(BALL_ANIMATION_DATA) as unknown as AnimationType,
+      })
+      .addAnimation({
+        id: 'second',
+        data: structuredClone(BULL_ANIMATION_DATA) as unknown as AnimationType,
+        defaultActiveAnimation: true,
+      })
+      .addAnimation({
+        id: 'third',
+        data: structuredClone(BALL_ANIMATION_DATA) as unknown as AnimationType,
+      });
+
+    const bytes = await source.toArrayBuffer();
+    const restored = await new DotLottie().fromArrayBuffer(bytes);
+
+    expect(restored.animations.map((anim) => anim.id)).toEqual(['first', 'second', 'third']);
+    expect(restored.manifest.initial?.animation).toBe('second');
+    expect(restored.animations.find((anim) => anim.id === 'first')?.defaultActiveAnimation).toBe(false);
+    expect(restored.animations.find((anim) => anim.id === 'second')?.defaultActiveAnimation).toBe(true);
+    expect(restored.animations.find((anim) => anim.id === 'third')?.defaultActiveAnimation).toBe(false);
+  });
+
+  test('omits manifest.initial when no animation is marked as default', async () => {
+    const source = new DotLottie()
+      .addAnimation({
+        id: 'a',
+        data: structuredClone(BALL_ANIMATION_DATA) as unknown as AnimationType,
+      })
+      .addAnimation({
+        id: 'b',
+        data: structuredClone(BULL_ANIMATION_DATA) as unknown as AnimationType,
+      });
+
+    const bytes = await source.toArrayBuffer();
+    const restored = await new DotLottie().fromArrayBuffer(bytes);
+
+    expect(restored.manifest.initial).toBeUndefined();
+    expect(restored.animations.every((anim) => anim.defaultActiveAnimation === false)).toBe(true);
+  });
+});
+
 describe('imageAssets', () => {
   test('Adds the Bull animation and checks number of images.', async () => {
     const dotlottie = await new DotLottie()

--- a/packages/dotlottie-js/src/v2/__tests__/node/dotlottie.spec.ts
+++ b/packages/dotlottie-js/src/v2/__tests__/node/dotlottie.spec.ts
@@ -605,6 +605,52 @@ describe('fromArrayBuffer', () => {
   });
 });
 
+describe('manifest.initial roundtrip', () => {
+  test('preserves manifest.initial.animation when the initial animation is not at index 0', async () => {
+    const source = new DotLottie()
+      .addAnimation({
+        id: 'first',
+        data: structuredClone(BALL_ANIMATION_DATA) as unknown as AnimationType,
+      })
+      .addAnimation({
+        id: 'second',
+        data: structuredClone(BULL_ANIMATION_DATA) as unknown as AnimationType,
+        defaultActiveAnimation: true,
+      })
+      .addAnimation({
+        id: 'third',
+        data: structuredClone(BALL_ANIMATION_DATA) as unknown as AnimationType,
+      });
+
+    const bytes = await source.toArrayBuffer();
+    const restored = await new DotLottie().fromArrayBuffer(bytes);
+
+    expect(restored.animations.map((anim) => anim.id)).toEqual(['first', 'second', 'third']);
+    expect(restored.manifest.initial?.animation).toBe('second');
+    expect(restored.animations.find((anim) => anim.id === 'first')?.defaultActiveAnimation).toBe(false);
+    expect(restored.animations.find((anim) => anim.id === 'second')?.defaultActiveAnimation).toBe(true);
+    expect(restored.animations.find((anim) => anim.id === 'third')?.defaultActiveAnimation).toBe(false);
+  });
+
+  test('omits manifest.initial when no animation is marked as default', async () => {
+    const source = new DotLottie()
+      .addAnimation({
+        id: 'a',
+        data: structuredClone(BALL_ANIMATION_DATA) as unknown as AnimationType,
+      })
+      .addAnimation({
+        id: 'b',
+        data: structuredClone(BULL_ANIMATION_DATA) as unknown as AnimationType,
+      });
+
+    const bytes = await source.toArrayBuffer();
+    const restored = await new DotLottie().fromArrayBuffer(bytes);
+
+    expect(restored.manifest.initial).toBeUndefined();
+    expect(restored.animations.every((anim) => anim.defaultActiveAnimation === false)).toBe(true);
+  });
+});
+
 describe('imageAssets', () => {
   test('Adds the Bull animation and checks number of images.', async () => {
     const dotlottie = await new DotLottie()

--- a/packages/dotlottie-js/src/v2/browser/dotlottie.ts
+++ b/packages/dotlottie-js/src/v2/browser/dotlottie.ts
@@ -341,6 +341,20 @@ export class DotLottie extends DotLottieCommon {
             }
           }
 
+          // Restore manifest.initial.animation → per-animation defaultActiveAnimation
+          // so that toArrayBuffer() → fromArrayBuffer() is a lossless roundtrip.
+          // _buildManifest() derives `manifest.initial` from this flag on write;
+          // without this, any parse → serialize cycle drops the initial marker.
+          if (manifest.initial?.animation) {
+            const initialAnimation = dotlottie.animations.find(
+              (anim) => anim.id === manifest.initial?.animation,
+            );
+
+            if (initialAnimation) {
+              initialAnimation.defaultActiveAnimation = true;
+            }
+          }
+
           // Go through the images and find to which animation they belong
           for (const image of tmpImages) {
             for (const parentAnimation of dotlottie.animations) {

--- a/packages/dotlottie-js/src/v2/node/dotlottie.ts
+++ b/packages/dotlottie-js/src/v2/node/dotlottie.ts
@@ -39,11 +39,13 @@ export async function toDotLottieV2(arrayBuffer: ArrayBuffer): Promise<DotLottie
 
     for (const animationId of animationIds) {
       const animation = await dotLottieV1.getAnimation(animationId, { inlineAssets: true });
+      const v1Settings = dotLottieV1.animations.find((anim) => anim.id === animationId);
 
       if (animation && animation.data) {
         dotLottieV2.addAnimation({
           data: animation.data,
           id: animationId,
+          defaultActiveAnimation: v1Settings?.defaultActiveAnimation ?? false,
         });
       }
     }
@@ -323,6 +325,20 @@ export class DotLottie extends DotLottieCommon {
                   });
                 }
               });
+            }
+          }
+
+          // Restore manifest.initial.animation → per-animation defaultActiveAnimation
+          // so that toArrayBuffer() → fromArrayBuffer() is a lossless roundtrip.
+          // _buildManifest() derives `manifest.initial` from this flag on write;
+          // without this, any parse → serialize cycle drops the initial marker.
+          if (manifest.initial?.animation) {
+            const initialAnimation = dotlottie.animations.find(
+              (anim) => anim.id === manifest.initial?.animation,
+            );
+
+            if (initialAnimation) {
+              initialAnimation.defaultActiveAnimation = true;
             }
           }
 


### PR DESCRIPTION
## Summary

The v2 parser silently drops `manifest.initial` on any parse → serialize roundtrip. This PR restores the flag so the serializer can re-emit `manifest.initial` correctly.

## Problem

`_buildManifest()` at [`src/v2/common/dotlottie.ts:475-476`](https://github.com/dotlottie/dotlottie-js/blob/main/packages/dotlottie-js/src/v2/common/dotlottie.ts#L475-L476) derives the output `manifest.initial.animation` from whichever animation has `defaultActiveAnimation === true`. But two code paths discard that flag on the way in:

1. **`fromArrayBuffer`** (node + browser builds) only spreads `manifest.animations[i]` per-animation settings into `addAnimation`. It never reads the top-level `manifest.initial.animation` to apply it to the matching animation's `defaultActiveAnimation` flag, so after parse every animation has the flag = `false`.
2. **`toDotLottieV2`** (v1 → v2 migration) calls `addAnimation` without threading the source v1 animation's `defaultActiveAnimation` through.

Net effect: a `.lottie` authored with `manifest.initial = { animation: "scene_B" }` is parsed, re-serialized (e.g. by a downstream optimizer like FMS), and the output silently loses the `initial` marker — even though neither the consumer nor the user asked for that.

## Fix

- After the outer parse loop in both [`src/v2/node/dotlottie.ts`](https://github.com/dotlottie/dotlottie-js/blob/main/packages/dotlottie-js/src/v2/node/dotlottie.ts) and [`src/v2/browser/dotlottie.ts`](https://github.com/dotlottie/dotlottie-js/blob/main/packages/dotlottie-js/src/v2/browser/dotlottie.ts), look up `manifest.initial?.animation` in `dotlottie.animations` and set `defaultActiveAnimation = true` on the match.
- In `toDotLottieV2`, thread `defaultActiveAnimation: v1Settings?.defaultActiveAnimation ?? false` through the v1 → v2 migration.

Symmetrical with what `_buildManifest()` reads on the serialize side — no other API surface changes.

## Test plan

- [x] New `describe('manifest.initial roundtrip', ...)` block added to both node and browser specs covering:
  - Positive: 3-animation `.lottie` with the second animation flagged as initial → `toArrayBuffer` → `fromArrayBuffer` → assert `manifest.initial.animation === 'second'` and only that animation has the flag.
  - Negative: no animation flagged → `manifest.initial` absent on the restored side, every animation has `defaultActiveAnimation === false`.
- [ ] `pnpm test` passes locally (couldn't run due to a local `npm.pkg.github.com` auth issue unrelated to this change — relying on CI).
- [ ] `pnpm type-check` passes (same caveat — relying on CI).