### PR TITLE
fix: grant pull-requests write permission to release workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,6 +15,7 @@ jobs:
 
     permissions:
       contents: write
+      pull-requests: write
       id-token: write
 
     steps:


### PR DESCRIPTION
## Summary
- Release workflow's `changesets/action@v1` step was failing with `Resource not accessible by integration` when trying to open the version-bump PR.
- Root cause: the job-level `permissions:` block declared `contents: write` and `id-token: write` but was missing `pull-requests: write`, so the scoped `GITHUB_TOKEN` could push the `changeset-release/main` branch but could not create the PR.
- Fix: add `pull-requests: write` to the release job's permissions.

## Failing log excerpt
```
/usr/bin/git push origin HEAD:changeset-release/main --force
 + e92a458...9d6963d HEAD -> changeset-release/main (forced update)
creating pull request
Error: HttpError: Resource not accessible by integration
```