### PR TITLE
fix: align theme Image slot schema with dotLottie 2.0 spec

### DIFF
--- a/packages/dotlottie-js/src/v2/__tests__/browser/theme.spec.ts
+++ b/packages/dotlottie-js/src/v2/__tests__/browser/theme.spec.ts
@@ -366,10 +366,9 @@ describe('LottieTheme', () => {
                 id: 'image-rule',
                 type: 'Image',
                 value: {
-                  id: 'image1',
+                  src: 'https://example.com/image.png',
                   width: 200,
                   height: 150,
-                  url: 'https://example.com/image.png',
                 },
               },
             ],
@@ -380,17 +379,15 @@ describe('LottieTheme', () => {
           type: 'Image';
           value: {
             height?: number;
-            id?: string;
-            url?: string;
+            src: string;
             width?: number;
           };
         };
 
         expect(rule.type).toBe('Image');
-        expect(rule.value.id).toBe('image1');
+        expect(rule.value.src).toBe('https://example.com/image.png');
         expect(rule.value.width).toBe(200);
         expect(rule.value.height).toBe(150);
-        expect(rule.value.url).toBe('https://example.com/image.png');
       });
 
       it('creates a theme with a minimal Image rule', () => {
@@ -401,7 +398,9 @@ describe('LottieTheme', () => {
               {
                 id: 'minimal-image-rule',
                 type: 'Image',
-                value: {},
+                value: {
+                  src: 'logo_dark.png',
+                },
               },
             ],
           },
@@ -410,7 +409,7 @@ describe('LottieTheme', () => {
         const rule = theme.data.rules[0] as { type: 'Image'; value: Record<string, unknown> };
 
         expect(rule.type).toBe('Image');
-        expect(rule.value).toEqual({});
+        expect(rule.value).toEqual({ src: 'logo_dark.png' });
       });
     });
 

--- a/packages/dotlottie-js/src/v2/__tests__/node/theme.spec.ts
+++ b/packages/dotlottie-js/src/v2/__tests__/node/theme.spec.ts
@@ -366,10 +366,9 @@ describe('LottieTheme', () => {
                 id: 'image-rule',
                 type: 'Image',
                 value: {
-                  id: 'image1',
+                  src: 'https://example.com/image.png',
                   width: 200,
                   height: 150,
-                  url: 'https://example.com/image.png',
                 },
               },
             ],
@@ -380,17 +379,15 @@ describe('LottieTheme', () => {
           type: 'Image';
           value: {
             height?: number;
-            id?: string;
-            url?: string;
+            src: string;
             width?: number;
           };
         };
 
         expect(rule.type).toBe('Image');
-        expect(rule.value.id).toBe('image1');
+        expect(rule.value.src).toBe('https://example.com/image.png');
         expect(rule.value.width).toBe(200);
         expect(rule.value.height).toBe(150);
-        expect(rule.value.url).toBe('https://example.com/image.png');
       });
 
       it('creates a theme with a minimal Image rule', () => {
@@ -401,7 +398,9 @@ describe('LottieTheme', () => {
               {
                 id: 'minimal-image-rule',
                 type: 'Image',
-                value: {},
+                value: {
+                  src: 'logo_dark.png',
+                },
               },
             ],
           },
@@ -410,7 +409,7 @@ describe('LottieTheme', () => {
         const rule = theme.data.rules[0] as { type: 'Image'; value: Record<string, unknown> };
 
         expect(rule.type).toBe('Image');
-        expect(rule.value).toEqual({});
+        expect(rule.value).toEqual({ src: 'logo_dark.png' });
       });
     });
 

--- a/packages/dotlottie-js/src/v2/common/schemas/theme.ts
+++ b/packages/dotlottie-js/src/v2/common/schemas/theme.ts
@@ -80,10 +80,9 @@ const ImageRuleSchema = object({
   ...BaseRuleSchema,
   type: literal('Image'),
   value: object({
-    id: optional(string()),
+    src: string(),
     width: optional(number()),
     height: optional(number()),
-    url: optional(string()),
   }),
 });
 


### PR DESCRIPTION
Updates the theme Image rule `value` to match the current [dotLottie 2.0 spec](https://dotlottie.io/spec/2.0/#themes):

- `url` (optional) → `src` (required)
- removes the redundant `id` field

Validation is valibot-driven, so `ImageRuleSchema` is the single source of truth. Tests updated in both node and browser specs.

**Note:** breaking for existing `url`-based themes.