### PR TITLE
chore: add changeset for theme Image slot schema fix

### DIFF
--- a/.changeset/theme-image-slot-schema.md
+++ b/.changeset/theme-image-slot-schema.md
@@ -1,0 +1,5 @@
+---
+'@dotlottie/dotlottie-js': patch
+---
+
+align theme Image slot schema with dotLottie 2.0 spec


### PR DESCRIPTION
Follow-up to #157. The changeset entry for the theme `Image` slot schema fix was missing from the merged PR, so the release workflow won't produce a changelog entry / version bump for it. This adds it as a `patch`.